### PR TITLE
Avoid returning a long int

### DIFF
--- a/lib/station.py
+++ b/lib/station.py
@@ -133,7 +133,7 @@ class station(nl80211_managed_object):
 		return struct.unpack('i', mac_hash)[0]
 
 	def __cmp__(self, other):
-		return self.__hash__() - other.__hash__()
+		return (self.__hash__() - other.__hash__()) & sys.maxint
 
 class station_list(custom_handler):
 	def __init__(self, ifidx, access=None, kind=nl.NL_CB_DEFAULT):


### PR DESCRIPTION
On 32 bit platforms, sometimes the __cmp__ returns a long int which will cause ```OverflowError: Python int too large to convert to C long``` to be thrown from line 155 in station.py.

This fix ensures we never return anything bigger than sys.maxint and thus we work around the problem.

A little bit of background, I am unsure if this is the best fix for the problem. On a raspberry pi I was seeing random crashes when certain devices connected to the AP (created by the pi) as I was iterating trough them.

The error was 

```
Python int too large to convert to C long
  File "/home/pi/.local/share/virtualenvs/py-nrf2018-q-3g8Z3z/local/lib/python2.7/site-packages/py80211/station.py", line 174, in handle
    s = self.store_station(sta)
  File "/home/pi/.local/share/virtualenvs/py-nrf2018-q-3g8Z3z/local/lib/python2.7/site-packages/py80211/station.py", line 164, in store_station
    if s == sta:
```

I'm happy to give more background and/or test cases if needed.